### PR TITLE
Support .NET 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ ARG BUILD_TOOLS_VERSION=36.1.0
 RUN <<EOF
   # Android toolchain
   set -e
+  yes | sdkmanager --licenses
   sdkmanager "platform-tools" "build-tools;${BUILD_TOOLS_VERSION}" "platforms;android-${ANDROID_API}"
 EOF
 


### PR DESCRIPTION
Support building a docker image for .NET 10. We'll lose the ability to build for .NET 9.0 and earlier due to the changes to the Dockerfile necessitate by Microsofts change of base image from Debian to Ubuntu.

When we merge this, tag the last commit before the merge on `master` with `dotnet-9` so we can easily check it out if we need to build a new .NET 9.0 image.

Fixes #5